### PR TITLE
Fix: use project based lint commands instead of global reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     },
     "scripts": {
         "test": "XDEBUG_MODE=coverage ./vendor/bin/phpunit",
-        "lint": "phpcs .",
-        "lint-fix": "phpcbf .",
+        "lint": "./vendor/bin/phpcs --standard=./phpcs.xml",
+        "lint-fix": "./vendor/bin/phpcbf --standard=./phpcs.xml",
         "static": [
             "Composer\\Config::disableProcessTimeout",
             "phpstan --memory-limit=1G"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,8 +3,8 @@
 	<description>10up PHPCS extended.</description>
 
 	<!-- Scan these directories -->
-	<file>./src/*</file>
-	<file>./tests/*</file>
+	<file>src</file>
+	<file>tests</file>
 
 	<!-- Use the 10up rulset -->
 	<rule ref="10up-Default" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,7 @@
 	<description>10up PHPCS extended.</description>
 
 	<!-- Scan these directories -->
+	<file>fixtures</file>
 	<file>src</file>
 	<file>tests</file>
 


### PR DESCRIPTION
### Description of the Change
This change is to make sure the project uses the locally available `phpcs` and `phpcbf` commands. Without this change, you must have `phpcs` installed globally on your system to run the command, and 2) the phpcs.xml is not respected because we are providing the `.` instead of looking in the config file for which directories to scan.

`/fixtures` has 4 files

`/src` has 6 files.

`/tests` has 5 files.

### How to test the Change

1. Checkout `trunk` 
2. Run `composer run lint`
3. 15 files are scanned
4. Run `./vendor/bin/phpcs --standard=phpcs.xml`
5. 11 files are scanned since the `fixtures` directory is not in the `phpcs.xml` config.

1. Checkout `fix/phpcs-commands` 
2. Run `composer run lint`
3. 15 files are scanned with the inclusion of the `fixtures` directory

### Changelog Entry
> Changed - `lint` and `lint-fix` commands now use locally available package

### Credits
Props @claytoncollie 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
