### PR TITLE
Fix/dont instantiate classes not extending interface

### DIFF
--- a/fixtures/classes/Standalone/Standalone.php
+++ b/fixtures/classes/Standalone/Standalone.php
@@ -5,6 +5,8 @@
  * @package TenupFrameworkTestClasses\Standalone
  */
 
+declare(strict_types = 1);
+
 namespace TenupFrameworkTestClasses\Standalone;
 
 /**
@@ -13,7 +15,7 @@ namespace TenupFrameworkTestClasses\Standalone;
  * @package TenupFrameworkTestClasses\Standalone
  */
 class Standalone {
- 	/**
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/fixtures/classes/Standalone/Standalone.php
+++ b/fixtures/classes/Standalone/Standalone.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Standalone Class
+ *
+ * @package TenupFrameworkTestClasses\Standalone
+ */
+
+namespace TenupFrameworkTestClasses\Standalone;
+
+/**
+ * Standalone Class
+ *
+ * @package TenupFrameworkTestClasses\Standalone
+ */
+class Standalone {
+ 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'init' ] );
+	}
+
+	/**
+	 * Init method.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		echo 'Hello from the Standalone class!';
+	}
+}

--- a/src/ModuleInitialization.php
+++ b/src/ModuleInitialization.php
@@ -145,6 +145,7 @@ class ModuleInitialization {
 			/** @var ModuleInterface $instantiated_class */
 			$instantiated_class = new $class();
 
+			do_action( 'tenup_framework_module_init__' . $slug, $instantiated_class );
 
 			// Assign the classes into the order they should be initialized.
 			$load_class_order[ intval( $instantiated_class->load_order() ) ][] = [

--- a/src/ModuleInitialization.php
+++ b/src/ModuleInitialization.php
@@ -145,11 +145,6 @@ class ModuleInitialization {
 			/** @var ModuleInterface $instantiated_class */
 			$instantiated_class = new $class();
 
-			// Make sure the class is a subclass of Module, so we can initialize it.
-			if ( ! in_array( 'TenupFramework\Module', $this->class_uses_recursive( $instantiated_class ), true ) ) {
-				unset( $instantiated_class );
-				continue;
-			}
 
 			// Assign the classes into the order they should be initialized.
 			$load_class_order[ intval( $instantiated_class->load_order() ) ][] = [
@@ -176,42 +171,6 @@ class ModuleInitialization {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Returns all traits used by a class and its traits.
-	 *
-	 * @param  object|string $class_to_search The class to check for traits.
-	 * @return array<string>
-	 */
-	protected function class_uses_recursive( $class_to_search ) {
-		if ( is_object( $class_to_search ) ) {
-			$class_to_search = get_class( $class_to_search );
-		}
-
-		$results = [];
-
-		foreach ( array_reverse( class_parents( $class_to_search ) ? class_parents( $class_to_search ) : [] ) + [ $class_to_search => $class_to_search ] as $class ) {
-			$results = array_merge( $results, $this->trait_uses_recursive( $class ) );
-		}
-
-		return array_unique( $results );
-	}
-
-	/**
-	 * Returns all traits used by a trait and its traits.
-	 *
-	 * @param  object|string $trait_to_search The trait to check for traits.
-	 * @return array<string>
-	 */
-	protected function trait_uses_recursive( $trait_to_search ) {
-		$traits_to_search = class_uses( $trait_to_search ) ? class_uses( $trait_to_search ) : [];
-
-		foreach ( $traits_to_search as $trait ) {
-			$traits_to_search = array_merge( $traits_to_search, $this->trait_uses_recursive( $trait ) );
-		}
-
-		return (array) $traits_to_search;
 	}
 
 	/**

--- a/src/ModuleInitialization.php
+++ b/src/ModuleInitialization.php
@@ -135,6 +135,11 @@ class ModuleInitialization {
 				continue;
 			}
 
+			// Check if the class implements ModuleInterface before instantiating it
+			if ( ! $reflection_class->implementsInterface( 'TenupFramework\ModuleInterface' ) ) {
+				continue;
+			}
+
 			// Initialize the class.
 			// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			/** @var ModuleInterface $instantiated_class */

--- a/tests/FrameworkTestSetup.php
+++ b/tests/FrameworkTestSetup.php
@@ -20,6 +20,8 @@ use function Brain\Monkey\Functions\stubTranslationFunctions;
 /**
  * Trait FrameworkTestSetup
  *
+ * @runTestsInSeparateProcesses
+ *
  * @package TenupFramework
  */
 trait FrameworkTestSetup {

--- a/tests/ModuleInitializationTest.php
+++ b/tests/ModuleInitializationTest.php
@@ -121,4 +121,17 @@ class ModuleInitializationTest extends TestCase {
 		$module = \TenupFramework\ModuleInitialization::get_module( 'TenupFrameworkTestClasses\DoesntExist' );
 		$this->assertFalse( $module );
 	}
+
+	/**
+	 * Test that only classes implementing ModuleInterface are initialized.
+	 *
+	 * @return void
+	 */
+	public function test_only_classes_implementing_module_interface_are_initialized() {
+		$module_init = \TenupFramework\ModuleInitialization::instance();
+		$module_init->init_classes( dirname( __DIR__, 1 ) . '/fixtures/classes' );
+
+		$this->assertTrue( did_action( 'tenup_framework_module_init__tenupframeworktestclasses-posttypes-demo' ) > 0, 'Demo was not initialized.' );
+		$this->assertFalse( did_action( 'tenup_framework_module_init__tenupframeworktestclasses-standalone-standalone' ) > 0, 'Standalone class was initialized.' );
+	}
 }


### PR DESCRIPTION
### Description of the Change

This PR ensures that only classes that extend the `ModuleInterface` interface have their constructor called. This fixes an issue where some non-module classes are also autoloaded by accident. 

### How to test the Change
See tests.

### Changelog Entry
* Fixed - A bug where non-module classes get auto-instantiated incorrectly.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ivanlopez @darylldoyle 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
