### PR TITLE
Feature/fix loading of broken classes

### DIFF
--- a/fixtures/classes/Loadable/BaseClass.php
+++ b/fixtures/classes/Loadable/BaseClass.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * BaseClass
+ *
+ * @package TenUpPlugin\Loadable
+ */
+
+declare(strict_types = 1);
+
+namespace TenupFrameworkTestClasses\Loadable;
+
+/**
+ * A base class.
+ */
+class BaseClass {
+
+}

--- a/fixtures/classes/Loadable/ChildClass.php
+++ b/fixtures/classes/Loadable/ChildClass.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * ChildClass
+ *
+ * @package TenUpPlugin\Loadable
+ */
+
+declare(strict_types = 1);
+
+namespace TenupFrameworkTestClasses\Loadable;
+
+use TenupFrameworkTestClasses\Loadable\BaseClass;
+
+/**
+ * Represents a class that extends the functionality of BaseClass.
+ */
+class ChildClass extends BaseClass {
+
+}

--- a/fixtures/classes/Loadable/InvalidChildClass.php
+++ b/fixtures/classes/Loadable/InvalidChildClass.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * InvalidChildClass
+ *
+ * @package TenUpPlugin\Loadable
+ */
+
+declare(strict_types = 1);
+
+namespace TenupFrameworkTestClasses\Loadable;
+
+/**
+ * Represents a class that attempts to extend a non-existent or invalid superclass.
+ *
+ * This class is invalid due to the parent class not being defined or available.
+ * Ensure that the parent class exists and is properly imported or declared
+ * in order to resolve this issue.
+ */
+class InvalidChildClass extends NonExistentClass {
+
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,8 @@ parameters:
 	paths:
 		- src/
 		- fixtures/classes/
+	excludePaths:
+		- fixtures/classes/Loadable/InvalidChildClass.php
 	reportUnmatchedIgnoredErrors: false
 	level: 10
 	ignoreErrors:

--- a/src/ModuleInitialization.php
+++ b/src/ModuleInitialization.php
@@ -125,9 +125,11 @@ class ModuleInitialization {
 				continue;
 			}
 
-			// Create a new reflection of the class.
-			// @phpstan-ignore argument.type
-			$reflection_class = new ReflectionClass( $class );
+			$reflection_class = $this->get_fully_loadable_class( $class );
+
+			if ( ! $reflection_class ) {
+				continue;
+			}
 
 			// Using reflection, check if the class can be initialized.
 			// If not, skip.
@@ -171,6 +173,26 @@ class ModuleInitialization {
 					$this->classes[ $slug ] = $class;
 				}
 			}
+		}
+	}
+
+	/**
+	 * Retrieves a fully loadable class using reflection.
+	 *
+	 * @param string $class_name The name of the class to load.
+	 *
+	 * @return false|ReflectionClass Returns a ReflectionClass instance if the class is loadable, or false if it is not.
+	 *
+	 * @phpstan-ignore missingType.generics
+	 */
+	public function get_fully_loadable_class( string $class_name ): false|ReflectionClass {
+		try {
+			// Create a new reflection of the class.
+			// @phpstan-ignore argument.type
+			return new ReflectionClass( $class_name );
+		} catch ( \Throwable $e ) {
+			// This includes ReflectionException, Error due to missing parent, etc.
+			return false;
 		}
 	}
 

--- a/tests/ModuleInitializationTest.php
+++ b/tests/ModuleInitializationTest.php
@@ -134,4 +134,17 @@ class ModuleInitializationTest extends TestCase {
 		$this->assertTrue( did_action( 'tenup_framework_module_init__tenupframeworktestclasses-posttypes-demo' ) > 0, 'Demo was not initialized.' );
 		$this->assertFalse( did_action( 'tenup_framework_module_init__tenupframeworktestclasses-standalone-standalone' ) > 0, 'Standalone class was initialized.' );
 	}
+
+	/**
+	 * Validate if the classes are fully loadable.
+	 *
+	 * @return void
+	 */
+	public function testIsClassFullyLoadable() {
+		$module_init = \TenupFramework\ModuleInitialization::instance();
+
+		$this->assertInstanceOf( 'ReflectionClass', $module_init->get_fully_loadable_class( '\TenupFrameworkTestClasses\Loadable\BaseClass' ) );
+		$this->assertInstanceOf( 'ReflectionClass', $module_init->get_fully_loadable_class( '\TenupFrameworkTestClasses\Loadable\ChildClass' ) );
+		$this->assertFalse( $module_init->get_fully_loadable_class( '\TenupFrameworkTestClasses\Loadable\InvalidChildClass' ) );
+	}
 }


### PR DESCRIPTION
### Description of the Change
This PR fixes an issue where classes are loaded, even if their parent classes are non-existent. For example, a missing plugin or something that extends `\WP_CLI`.

### How to test the Change
Unit tests are included.

### Changelog Entry
> Fixed - Issue where the autoloader loads classes with non-existent parents.

### Credits
Props @darylldoyle 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
