### PR TITLE
Fix: Allow opting out of Caching for environments that don't Support filesystem modifications

### DIFF
--- a/docs/Autoloading.md
+++ b/docs/Autoloading.md
@@ -82,7 +82,7 @@ Environment caching:
 - Discovery results are cached only in production and staging environments (per `wp_get_environment_type()`).
 - Cache is stored under the directory you pass to `init_classes()`, in a "class-loader-cache" folder (e.g., `YOUR_PLUGIN_INC . 'class-loader-cache'`).
 - To refresh: delete that folder; it will be rebuilt automatically.
-- Caching is skipped entirely when the constant `VIP_GO_APP_ENVIRONMENT` is defined.
+- Caching is skipped entirely when the constant `VIP_GO_APP_ENVIRONMENT` is defined or when `TENUP_FRAMEWORK_DISABLE_CACHE` is set to `true`. Use `define( 'TENUP_FRAMEWORK_DISABLE_CACHE', true )` in environments that don't support writable file systems.
 
 ## Defining a Module
 ```php

--- a/docs/Modules-and-Initialization.md
+++ b/docs/Modules-and-Initialization.md
@@ -37,9 +37,9 @@ ModuleInitialization performs the following steps:
 
 Environment cache behavior
 - Where cache lives: under the directory you pass to `init_classes()`, in a `class-loader-cache` folder (e.g., `YOUR_PLUGIN_INC . 'class-loader-cache'`).
-- When it’s used: only in `production` and `staging` environment types (`wp_get_environment_type()`).
+- When it's used: only in `production` and `staging` environment types (`wp_get_environment_type()`).
 - How to clear: delete the `class-loader-cache` folder; it will be rebuilt on next discovery.
-- How to disable in development: use `development` or `local` environment types, or define `VIP_GO_APP_ENVIRONMENT` to skip the cache.
+- How to disable: use `development` or `local` environment types, define `VIP_GO_APP_ENVIRONMENT`, or set `define( 'TENUP_FRAMEWORK_DISABLE_CACHE', true )` to skip the cache. The `TENUP_FRAMEWORK_DISABLE_CACHE` constant is useful for environments that don't support writable file systems.
 
 Hooks
 - Action: `tenup_framework_module_init__{slug}` — fires before each module’s `register()` runs.

--- a/src/ModuleInitialization.php
+++ b/src/ModuleInitialization.php
@@ -68,7 +68,22 @@ class ModuleInitialization {
 		$class_finder->classes();
 
 		// If we are in production or staging, cache the class loader to improve performance.
-		if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) && in_array( wp_get_environment_type(), [ 'production', 'staging' ], true ) ) {
+		// Skip caching if TENUP_FRAMEWORK_DISABLE_CACHE is set to true.
+		$is_vip_environment           = defined( 'VIP_GO_APP_ENVIRONMENT' );
+		$is_cache_disabled            = defined( 'TENUP_FRAMEWORK_DISABLE_CACHE' ) && constant( 'TENUP_FRAMEWORK_DISABLE_CACHE' );
+
+		// VIP is a special case that we always want to skip caching for.
+		if ( $is_vip_environment ) {
+			$is_cache_disabled = true;
+		}
+
+		$is_production_or_staging_env = in_array( wp_get_environment_type(), [ 'production', 'staging' ], true );
+
+		$should_cache = ! $is_vip_environment
+			&& ! $is_cache_disabled
+			&& $is_production_or_staging_env;
+
+		if ( $should_cache ) {
 			$class_finder->withCache(
 				__NAMESPACE__,
 				new FileDiscoverCacheDriver( $dir . '/class-loader-cache' )


### PR DESCRIPTION
This pull request updates the caching behavior for class discovery in the framework, making it easier to disable caching in environments that do not support writable file systems. The most important changes clarify and implement a new constant, `TENUP_FRAMEWORK_DISABLE_CACHE`, which allows developers to skip caching regardless of environment type. Documentation has also been updated to reflect this new option.

**Caching logic improvements:**

* Updated the caching condition in `src/ModuleInitialization.php` to support disabling cache when `TENUP_FRAMEWORK_DISABLE_CACHE` is set to `true`, in addition to skipping cache on `VIP_GO_APP_ENVIRONMENT`. This makes cache control more flexible for various environments.

**Documentation updates:**

* Revised `docs/Autoloading.md` to explain that caching is now skipped when `TENUP_FRAMEWORK_DISABLE_CACHE` is `true`, and provided guidance for using this constant in environments without writable file systems.
* Updated `docs/Modules-and-Initialization.md` to include `TENUP_FRAMEWORK_DISABLE_CACHE` as a way to disable caching, along with examples of its usage and explanation of its intended purpose.