### PR TITLE
Disable chains

### DIFF
--- a/src/ModuleInitialization.php
+++ b/src/ModuleInitialization.php
@@ -68,6 +68,8 @@ class ModuleInitialization {
 		$class_finder = Discover::in( $dir );
 		// Only fetch classes.
 		$class_finder->classes();
+		// Disable inheritance chain resolution
+		$class_finder->withoutChains();
 
 		// If we are in production or staging, cache the class loader to improve performance.
 		if ( $this->should_use_cache() ) {


### PR DESCRIPTION
### Description of the Change
This pull request introduces a small but important performance optimization to the `get_classes` method in `ModuleInitialization.php`. The change disables inheritance chain resolution when discovering classes, which can make class discovery faster and more efficient.

- Performance optimization:
  * Updated the `get_classes` method to call `withoutChains()` on the `$class_finder`, disabling inheritance chain resolution during class discovery.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #25

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry

* Developer - disables inheritance chain resolution when discovering classes

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @claytoncollie, @darylldoyle 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
